### PR TITLE
Fix pom.xml error and add LWJGL Arm64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,6 @@
             <version>2.8.1</version>
         </dependency>
 
-        <!-- LWJGL依赖 -->
         <dependency>
             <groupId>org.lwjgl</groupId>
             <artifactId>lwjgl</artifactId>


### PR DESCRIPTION
I wanted to build this client today, but when I ran mvn compile, it reported errors about missing dependencies. So I added the MavenCentral and Minecraft repositories to enable successful downloading of these dependencies.

The dependencies that couldn’t be downloaded were:

· com.ibm.icu:icu4j-core-mojang:jar
· oshi-project:oshi-core:jar:1.1

It seemed like they couldn’t be found on Jitpack.io. Initially, I added the MavenCentral repository, but strangely, even though I saw the dependencies listed there, the download still failed. So I added the official Minecraft repository, and this time the download succeeded. That’s the reason I submitted this PR.

---

By the way, I also added the LWJGL Arm64 dependency. If you have any concerns about it, feel free to remove it.